### PR TITLE
Make language consistent with best practices.

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -17,7 +17,6 @@ tags:
 
   - name: booking [optional]
     description: endpoints that can faciliate processes in the booking process, but are not necessary for a minimal viable product. You can think of getting information, updating (parts of) a booking (not the state!), adding and removing subscriptions (webhook), etc.
-    description: endpoints that can faciliate processes in the booking process, but are not necessary for a minimal viable product. You can think of getting information, updating (parts of) a booking (not the state!), adding and removing subscriptions (webhook), etc.
 
   - name: trip execution
     description: supports the complete trip execution process. It contains f.i. getting an available asset, assigning the asset to the leg, starting, pausing, finishing a leg (all by using the POST /legs/{id}/events) or updating a leg (not the state!).
@@ -88,10 +87,11 @@ paths:
                 type: string
                 example: '/planning-options/1234'
             Content-Language:
-              description: ISO 639-1 two letter language code
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
               required: true
             Expires:
               description: the result is valid until this timestamp. After this timestamp the planningOption will be discarded, if cannot become a bookingOption.
@@ -136,10 +136,11 @@ paths:
                 $ref: '#/components/schemas/booking'
           headers:
             Content-Language:
-              description: ISO 639-1 two letter language code
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
               required: true
             Expires:
               description: The result is valid until this timestamp. The pending booking is expired after this timestamp. This option can be used, but there is also a facility to use the webhook, mentioned in '#/component/schemas/booking'.
@@ -188,11 +189,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/booking'
           headers:
-           'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -228,11 +231,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/booking'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '204':
           $ref: '#/components/responses/204NoContent'
         '400':
@@ -270,11 +275,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/booking'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '404':
@@ -302,11 +309,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/booking'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -406,11 +415,13 @@ paths:
         '200':
           description: The bookings matching the query
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
           content:
             application/json:
               schema:
@@ -469,11 +480,13 @@ paths:
         '200':
           description: Available assets for the booking. If no suitable assets are found an empty array is to be returned.
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
           content:
             application/json:
               schema:
@@ -679,11 +692,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/stationInformation'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -703,11 +718,13 @@ paths:
         '200':
           description: Available assets or asset-types. In case assets are replied, the realtime location is also available.
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
           content:
             application/json:
               schema:
@@ -742,11 +759,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/systemAlert'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -772,11 +791,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/systemCalendar'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -803,11 +824,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/systemHours'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -832,11 +855,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/systemInformation'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -864,11 +889,13 @@ paths:
                 items:
                   $ref: '#/components/schemas/systemPricingPlan'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -939,11 +966,13 @@ paths:
         '200':
           description: journal entries
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
           content:
             application/json:
               schema:
@@ -982,11 +1011,13 @@ paths:
         '200':
           description: journal entry received, will be processed (state = INVOICED)
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
           content:
             application/json:
               schema:
@@ -1023,11 +1054,13 @@ paths:
         '200':
           description: support request acknowledged
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -1060,11 +1093,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/supportStatus'
           headers:
-            'Content-Language':
-              description: ISO 639-1 two letter language code
+            Content-Language:
+              description: The language/localization of user-facing content
               example: nl
               schema:
                 type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -1078,11 +1113,11 @@ components:
       type: object
       properties:
         streetAddress:
-          description: street address, including number OR PO box number, eventually extended with internal referencce like room number
+          description: street address, including number OR PO box number, eventually extended with internal referencce like room number, could match Content-Language
           type: string
           example: example street 18, 2nd floor, 18-B33
         areaReference:
-          description: city or town, principal subdivision such as province, state or county
+          description: city or town, principal subdivision such as province, state or county, could match Content-Language
           type: string
           example: Smallcity, Pinetree county
         postalCode:
@@ -1468,13 +1503,13 @@ components:
           description: A URI reference [RFC3986] that identifies the problem type.  This specification encourages that, when  dereferenced, it provide human-readable documentation for the problem type (e.g., using HTML [W3C.REC-html5-20141028]).  When this member is not present, its value is assumed to be "about:blank".
         title:
           type: string
-          description: A short, human-readable summary of the problem type.  It SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization (e.g., using proactive content negotiation; see [RFC7231], Section 3.4).
+          description: A short, human-readable summary of the problem type.  It SHOULD NOT change from occurrence to occurrence of the problem, except to match Content-Language
         status:
           type: number
           description: The HTTP status code ([RFC7231], Section 6) generated by the origin server for this occurrence of the problem.
         detail:
           type: string
-          description: A human-readable explanation specific to this occurrence of the problem.
+          description: A human-readable explanation specific to this occurrence of the problem, could match Content-Language
         instance:
           type: string
           description: A URI reference that identifies the specific occurrence of the problem.  It may or may not yield further information if dereferenced.
@@ -1492,7 +1527,7 @@ components:
             category:
               $ref: '#/components/schemas/journalCategory'
             description:
-              description: free text to describe the extra costs. Mandatory in case of 'OTHER'
+              description: free text to describe the extra costs. Mandatory in case of 'OTHER', should match Content-Language
               type: string
             number:
               type: number
@@ -1515,7 +1550,7 @@ components:
           description: is this fare an estimation?
           type: boolean
         description:
-          description: user friendly description of the fare (e.g. 'full fare')
+          description: user friendly description of the fare (e.g. 'full fare'), should match Content-Language
           type: string
         class:
           description: in the future we'll set up an enumeration of possible "fare classes". For now it's free format.
@@ -1674,7 +1709,7 @@ components:
           enum: [PREPARE, ASSIGN_ASSET, SET_IN_USE, PAUSE, START_FINISHING, FINISH, ISSUE]
         comment:
           type: string
-          description: free text
+          description: free text, should match Content-Language
         asset:
           $ref: '#/components/schemas/asset'
 
@@ -1725,7 +1760,7 @@ components:
           example: VEHICLE_NOT_AVAILABLE
         comment:
           type: string
-          description: free text
+          description: free text, should match Content-Language
 
     operatorLeg:
       allOf:
@@ -1734,15 +1769,16 @@ components:
           properties:
             operatorName:
               type: string
+              description: Name of the operator, could match Content-Language
             operatorMaasId:
               type: string
               description: the maasId from the operator
             operatorDescription:
               type: string
-              description: short description of the operator
+              description: short description of the operator, should match Content-Language
             operatorContact:
               type: string
-              description: contact information
+              description: contact information, should match Content-Language
 
     optionsLeg:
       allOf:
@@ -1788,7 +1824,7 @@ components:
         - lat
       properties:
         name:
-          description: Human readable name of the place
+          description: Human readable name of the place, could match Content-Language
           type: string
         stopReference:
           type: array
@@ -1912,7 +1948,7 @@ components:
           example: XX:Y:12345678
         name:
           type: string
-          description: public name of the station
+          description: public name of the station, could match Content-Language
           example: Island Central
         coordinates:
           $ref: '#/components/schemas/coordinates'
@@ -1920,7 +1956,7 @@ components:
           $ref: '#/components/schemas/address'
         crossStreet:
           type: string
-          description: Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.
+          description: Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc, should match Content-Language
           example: on the corner with Secondary Road
         regionId:
           type: string
@@ -2006,11 +2042,11 @@ components:
           example: http://www.rentmyfreebike.com/alerts
         summary:
           type: string
-          description: A short summary of this alert to be displayed to the customer
+          description: A short summary of this alert to be displayed to the customer, should match Content-Language
           example: station closed
         description:
           type: string
-          description: Detailed text description of the alert
+          description: Detailed text description of the alert, should match Content-Language
           example: station closed indefinitely due to vandalism
         lastUpdated:
           $ref: '#/components/schemas/timestamp'
@@ -2091,12 +2127,14 @@ components:
             type: string
             example: XXTO0001
           language:
-            description: An IETF language tag indicating the language that will be used throughout the rest of the files. This is a string that defines a single language tag only.
-            type: string
-            format: ietf
-            example: eng
+            description: The languages supported by this operator for user-facing text. These can be requested using the Accept-Language header and should then be returned in Content-Language
+            type: array
+            items:
+              type: string
+              format: One IETF BCP 47 (RFC 5646) language tag
+              example: fr-FR
           name:
-            description: Full name of the system to be displayed to customers
+            description: Full name of the system to be displayed to customers, could match Content-Language
             type: string
             example: FreeBike
           shortName:
@@ -2104,7 +2142,7 @@ components:
             type: string
             example: FB
           operator:
-            description: Name of the operator of the system
+            description: Name of the operator of the system, could match Content-Language
             type: string
             example: FreeBike
           url:
@@ -2164,7 +2202,7 @@ components:
           example: https://www.rentmyfreebike.com/freeplan
         name:
           type: string
-          description: name of this pricing scheme
+          description: name of this pricing scheme, could match Content-Language
           example: Free Plan
         fare:
           $ref: '#/components/schemas/fare'
@@ -2173,7 +2211,7 @@ components:
           description: false indicates that no additional tax will be added (either because tax is not charged, or because it is included) true indicates that tax will be added to the base price
         description:
           type: string
-          description: Text field describing the particular pricing plan in human readable terms. This should include the duration, price, conditions, etc. that the publisher would like users to see. This is intended to be a human-readable description and should not be used for automatic calculations
+          description: Text field describing the particular pricing plan in human readable terms. This should include the duration, price, conditions, etc. that the publisher would like users to see. This is intended to be a human-readable description and should not be used for automatic calculations, should match Content-Language
           example: Unlimited plan for free bikes, as long as you don't break them!
 
     systemRegion:
@@ -2188,7 +2226,7 @@ components:
           example: BikeRegion
         name:
           type: string
-          description: Public name for this region
+          description: Public name for this region, could match Content-Language
           example: BikeTown
         serviceArea:
           description: The area served by the region (i.e. where one may travel using the service's assets)
@@ -2273,10 +2311,10 @@ components:
           description: true indicates cabrio required
         colour:
           type: string
-          description: colour of the asset
+          description: colour of the asset, should match Content-Language
         cargo:
           type: string
-          description: describes options to carry cargo
+          description: describes options to carry cargo, should match Content-Language
         easyAccessibility:
           type: string
           description: describes if asset is or needs to be easily accessible
@@ -2323,7 +2361,7 @@ components:
           description: true indicates winter tires required
         other:
           type: string
-          description: free text to describe asset
+          description: free text to describe asset, should match Content-Language
         meta:
           description: this array can contain extra information about the type of asset. For instance values from the 'Woordenboek Reizigerskenmerken'. [https://github.com/efel85/TOMP-API/issues/17]. These values can also be used in the planning-options.
           type: array
@@ -2356,8 +2394,9 @@ components:
       required: true
       schema:
         type: string
-      description: ISO 639-1 two letter language code
-      example: NL
+        format: A comma-separated list of BCP 47 (RFC 5646) language tags and optional weights as described in IETF RFC7231 section 5.3.5
+      description: A list of the languages/localizations the user would like to see the results in. For user privacy and ease of use on the TO side, this list should be kept as short as possible, ideally just one language tag from the list in operator/information
+      example: nl, de;q=0.7
     api:
       in: header
       name: Api


### PR DESCRIPTION
For issue #138 

- Specify all TO languages in operator/information in an array of BCP 47 language tags
- Format Accept-Language header according to RFC7231
- Format Content-Language according to BCP 47