### PR TITLE
Update to the planning module

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -64,15 +64,15 @@ paths:
     post:
       description:
         Returns plannings for the given travel plan. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
-        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `bookable`, requesting the TO to provide booking IDs to reference to during communication with the MP.
+        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `booking-intent`, requesting the TO to provide booking IDs to reference to during communication with the MP.
         <p>see (2.1) in the process flow - planning
       tags:
         - planning
         - TO
       parameters:
-        - name: bookable
+        - name: booking-intent
           in: query
-          description: Specifies whether bookable IDs should be returned with the results
+          description: Specifies whether IDs should be returned for the leg options that can be referred to when booking
           schema:
             type: boolean
             default: false

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -1436,9 +1436,10 @@ components:
         conditionType:
           description: The specific subclass of condition, should match the schema name exactly
           type: string
-        name:
-          description: TODO
+        id:
+          description: An identifier for this condition that can be used to refer to this condition
           type: string
+          example: deposit50eu
 
     conditionDeposit:
       description: in case the TO demands a deposit before usage. Requesting and refunding should be done using the /payment/claim-extra-costs endpoint.
@@ -2042,10 +2043,10 @@ components:
         pricing:
           $ref: "#/components/schemas/fare"
         conditions:
-          description: Indices of the conditions in the parent planningOption that apply to this option
+          description: Ids of the conditions in the parent planningOption that apply to this option
           type: array
           items:
-            type: number
+            type: string
         operatorName:
           type: string
           description: Name of the operator, these should not be included if they are the TO itself, could match Content-Language

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -101,11 +101,6 @@ paths:
                 type: string
                 format: One IETF BCP 47 (RFC 5646) language tag
               required: true
-            Expires:
-              description: the result is valid until this timestamp. After this timestamp the planningOption may no longer be available or change
-              schema:
-                $ref: "#/components/schemas/timestamp"
-              required: true
         "202":
           $ref: "#/components/responses/202Accepted"
         "400":
@@ -143,11 +138,6 @@ paths:
               schema:
                 type: string
                 format: One IETF BCP 47 (RFC 5646) language tag
-              required: true
-            Expires:
-              description: the result is valid until this timestamp. After this timestamp the planningOption may no longer be available or change
-              schema:
-                $ref: "#/components/schemas/timestamp"
               required: true
         "401":
           $ref: "#/components/responses/401Unauthorized"

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -69,6 +69,13 @@ paths:
       tags:
         - planning
         - TO
+      parameters:
+        - name: bookable
+          in: query
+          description: Specifies whether bookable IDs should be returned with the results
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           application/json:
@@ -1971,9 +1978,6 @@ components:
               type: array
               items:
                 type: string
-            provideIds:
-              description: default false (during planning phase). Whenever entering the booking phase to present the options to the user, set it to true to refert to this option. The returned ID can be used througout the complete process. [https://github.com/efel85/TOMP-API/issues/57]
-              type: boolean
             users:
               type: array
               items:

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -126,7 +126,7 @@ paths:
         - TO
       responses:
         "200":
-          description: The booking was found
+          description: The planning option was found
           content:
             application/json:
               schema:
@@ -1401,26 +1401,24 @@ components:
         assetClass:
           $ref: "#/components/schemas/assetClass"
 
-    compositeLeg:
+    compositeOption:
       description: this leg type should be used when returning multiple legs to fullfil a single request from A to B. For instance handling overlegs or when acting as broker for multiple sub contractors.
-      allOf:
-        - $ref: "#/components/schemas/planningResult"
-        - type: object
-          properties:
-            id:
-              description: unique ID (TO's perspective) for this option. This ID is used during the complete process booking of a specific asset or an asset of a specific type. If the availability-request is not fired within f.i. 30 minutes, it can savely be removed.
-              type: string
-            pricing:
-              $ref: "#/components/schemas/fare"
-            legs:
-              type: array
-              items:
-                $ref: "#/components/schemas/operatorLeg"
-            conditions:
-              description: references to the 'conditions' array (start of this object).
-              type: array
-              items:
-                type: string
+      type: object
+      required:
+        - optionType
+        - parts
+      properties:
+        optionType:
+          type: string
+        id:
+          description: A unique id which can be referred to when creating a booking
+          type: string
+        pricing:
+          $ref: "#/components/schemas/fare"
+        parts:
+          type: array
+          items:
+            $ref: "#/components/schemas/simpleOption"
 
     condition:
       oneOf:
@@ -1909,34 +1907,6 @@ components:
           type: string
           description: free text, should match Content-Language
 
-    operatorLeg:
-      allOf:
-        - $ref: "#/components/schemas/simpleLeg"
-        - type: object
-          properties:
-            operatorName:
-              type: string
-              description: Name of the operator, could match Content-Language
-            operatorMaasId:
-              type: string
-              description: the maasId from the operator
-            operatorDescription:
-              type: string
-              description: short description of the operator, should match Content-Language
-            operatorContact:
-              type: string
-              description: contact information, should match Content-Language
-
-    optionsLeg:
-      allOf:
-        - $ref: "#/components/schemas/period"
-        - type: object
-          properties:
-            from:
-              $ref: "#/components/schemas/coordinates"
-            to:
-              $ref: "#/components/schemas/coordinates"
-
     period:
       type: object
       properties:
@@ -2024,21 +1994,18 @@ components:
         validUntil:
           $ref: "#/components/schemas/timestamp"
         conditions:
-          description: An array of the conditions that apply to at least one of the results
+          description: An array of the conditions that apply to at least one of the options
           type: array
           items:
             $ref: "#/components/schemas/condition"
-        results:
+        options:
           type: array
           items:
-            $ref: "#/components/schemas/planningResult"
-
-    planningResult:
-      oneOf:
-        - $ref: "#/components/schemas/simpleLeg"
-        - $ref: "#/components/schemas/compositeLeg"
-      discriminator:
-        propertyName: resultType
+            oneOf:
+              - $ref: "#/components/schemas/singleOption"
+              - $ref: "#/components/schemas/compositeOption"
+            discriminator:
+              propertyName: optionType
 
     polygon:
       type: object
@@ -2055,25 +2022,55 @@ components:
       items:
         $ref: "#/components/schemas/keyValue"
 
-    simpleLeg:
+    simpleOption:
+      type: object
+      required:
+        - from
+        - typeOfAsset
+        - conditions
+      properties:
+        from:
+          $ref: "#/components/schemas/coordinates"
+        to:
+          $ref: "#/components/schemas/coordinates"
+        startTime:
+          $ref: "#/components/schemas/timestamp"
+        endTime:
+          $ref: "#/components/schemas/timestamp"
+        asset:
+          $ref: "#/components/schemas/typeOfAsset"
+        pricing:
+          $ref: "#/components/schemas/fare"
+        conditions:
+          description: Indices of the conditions in the parent planningOption that apply to this option
+          type: array
+          items:
+            type: number
+        operatorName:
+          type: string
+          description: Name of the operator, these should not be included if they are the TO itself, could match Content-Language
+        operatorMaasId:
+          type: string
+          description: the maasId from the operator
+        operatorDescription:
+          type: string
+          description: short description of the operator, should match Content-Language
+        operatorContact:
+          type: string
+          description: contact information, should match Content-Language
+
+    singleOption:
       allOf:
-        - $ref: "#/components/schemas/planningResult"
+        - $ref: "#/components/schemas/simpleOption"
         - type: object
+          required:
+            - optionType
           properties:
-            id:
-              description: unique ID (TO's perspective) for this option. This ID is used during the complete process booking of a specific asset or an asset of a specific type. If the availability-request is not fired within f.i. 30 minutes, it can savely be removed.
+            optionType:
               type: string
-            leg:
-              $ref: "#/components/schemas/optionsLeg"
-            typeOfAsset:
-              $ref: "#/components/schemas/typeOfAsset"
-            pricing:
-              $ref: "#/components/schemas/fare"
-            conditions:
-              description: references to the 'conditions' array (start of this object).
-              type: array
-              items:
-                type: string
+            id:
+              description: A unique id which can be referred to when creating a booking
+              type: string
 
     stationInformation:
       type: object

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -1964,12 +1964,12 @@ components:
             - from
           properties:
             from:
-              $ref: "#/components/schemas/coordinates"
+              $ref: "#/components/schemas/place"
             radius:
               description: Maximum distance a user wants to travel to reach asset in metres, e.g. 500 metres
               type: number
             to:
-              $ref: "#/components/schemas/coordinates"
+              $ref: "#/components/schemas/place"
             travellers:
               description: the amount of people that have to travel from `from` to `to` [https://github.com/efel85/TOMP-API/issues/56]
               type: number

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -102,7 +102,7 @@ paths:
                 format: One IETF BCP 47 (RFC 5646) language tag
               required: true
             Expires:
-              description: the result is valid until this timestamp. After this timestamp the planningOption will be discarded, if cannot become a bookingOption.
+              description: the result is valid until this timestamp. After this timestamp the planningOption may no longer be available or change
               schema:
                 $ref: "#/components/schemas/timestamp"
               required: true
@@ -112,6 +112,49 @@ paths:
           $ref: "#/components/responses/400BadRequest"
         "401":
           $ref: "#/components/responses/401Unauthorized"
+
+  /planning-options/{id}:
+    parameters:
+      - $ref: "#/components/parameters/acceptLanguage"
+      - $ref: "#/components/parameters/api"
+      - $ref: "#/components/parameters/apiVersion"
+      - name: id
+        in: path
+        description: Planning option identifier
+        required: true
+        schema:
+          type: string
+    get:
+      description: Returns the planning option.
+      tags:
+        - planning
+        - TO
+      responses:
+        "200":
+          description: The booking was found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/planningOption"
+          headers:
+            Content-Language:
+              description: The language/localization of user-facing content
+              example: nl
+              schema:
+                type: string
+                format: One IETF BCP 47 (RFC 5646) language tag
+              required: true
+            Expires:
+              description: the result is valid until this timestamp. After this timestamp the planningOption may no longer be available or change
+              schema:
+                $ref: "#/components/schemas/timestamp"
+              required: true
+        "401":
+          $ref: "#/components/responses/401Unauthorized"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "410":
+          $ref: "#/components/responses/410Gone"
 
   /bookings/:
     parameters:

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -20,7 +20,7 @@ tags:
     description: endpoints that can faciliate processes in the booking process, but are not necessary for a minimal viable product. You can think of getting information, updating (parts of) a booking (not the state!), adding and removing subscriptions (webhook), etc.
 
   - name: trip execution
-    description: supports the complete trip execution process. It contains f.i. getting an available asset, assigning the asset to the leg, starting, pausing, finishing a leg (all by using the POST /legs/{id}/events) or updating a leg (not the state!).
+    description: supports the complete trip execution process. It contains f.i. getting an available asset, assigning the asset to the leg, starting, pausing, finishing a leg (all by using the POST /executions/{id}/events) or updating an execution (not the state!).
 
   - name: trip execution [optional]
     description: endpoints that can facilitate processes in the trip execution process, but are not necessary for a minimal viable product.
@@ -32,10 +32,10 @@ tags:
     description: gives information about systems, stations, operating hours [from GBFS]
 
   - name: payment
-    description: arranges financial settlement for legs
+    description: arranges financial settlement for executions
 
   - name: support
-    description: support for the user while the leg is being executed
+    description: support for the user while the leg execution is ongoing
 
   - name: TO
     description: the Transport Operator's endpoints
@@ -56,14 +56,14 @@ security:
   - OpenId: []
 
 paths:
-  /planning-options/:
+  /plannings/:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
       - $ref: "#/components/parameters/apiVersion"
     post:
       description:
-        Returns planning options for the given travel plan. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
+        Returns plannings for the given travel plan. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
         During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `bookable`, requesting the TO to provide booking IDs to reference to during communication with the MP.
         <p>see (2.1) in the process flow - planning
       tags:
@@ -80,20 +80,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/travelPlan"
+              $ref: "#/components/schemas/planningRequest"
       responses:
         "201":
           description: Available transport methods matching the given query parameters. If no transport methods are available, an empty array is returned.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/planningOption"
+                $ref: "#/components/schemas/planning"
           headers:
             Location:
-              description: The URI where the most up to date version of the created option can be found. Not required.
+              description: The URI where the most up to date version of the created planning result can be found. Not required.
               schema:
                 type: string
-                example: "/planning-options/1234"
+                example: "/plannings/1234"
             Content-Language:
               description: The language/localization of user-facing content
               example: nl
@@ -108,29 +108,29 @@ paths:
         "401":
           $ref: "#/components/responses/401Unauthorized"
 
-  /planning-options/{id}:
+  /plannings/{id}:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
       - $ref: "#/components/parameters/apiVersion"
       - name: id
         in: path
-        description: Planning option identifier
+        description: Planning identifier
         required: true
         schema:
           type: string
     get:
-      description: Returns the planning option.
+      description: Returns the planning result.
       tags:
         - planning
         - TO
       responses:
         "200":
-          description: The planning option was found
+          description: The planning was found
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/planningOption"
+                $ref: "#/components/schemas/planning"
           headers:
             Content-Language:
               description: The language/localization of user-facing content
@@ -153,7 +153,7 @@ paths:
       - $ref: "#/components/parameters/apiVersion"
     post:
       description:
-        Creates a new `Booking` for the TO in **Pending** state. The ID of the posted booking should be the ID provided in the previous step (planningOption).
+        Creates a new `Booking` for the TO in **Pending** state. The ID of the posted booking should be the ID provided in the previous step (planning).
         <p>The Booking may be modified in the response, e.g. location being adjusted for a more suitable pick-up location.
         In addition, the service may contain a **meta** attribute for arbitrary TO metadata that the TO needs later, and **token** attribute depicting how long the current state is valid.
         <p>The optional webhook can be used to post updates from TO to MP. If it isn't used, the subscription possibility in this API can be used or the events can be posted directly.
@@ -162,7 +162,7 @@ paths:
         - booking
         - TO
       requestBody:
-        description: One of available options, returned by /planning-options, with an ID.
+        description: One of available legs, returned by /planning, with an ID.
         required: true
         content:
           application/json:
@@ -502,7 +502,7 @@ paths:
         "410":
           $ref: "#/components/responses/410Gone"
 
-  /legs/{id}/available-assets:
+  /executions/{id}/available-assets:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
@@ -514,7 +514,7 @@ paths:
         schema:
           type: string
     get:
-      description: Returns a list of available assets for the given booking. These assets can be used to POST to /legs/{id}/asset if no specific asset is assigned by the TO. If picking an asset is not allowed for this booking, or one already has been, 403 should be returned. If the booking is unknown, 404 should be returned. See (4.7) in the process flow. - trip execution
+      description: Returns a list of available assets for the given booking. These assets can be used to POST to /executions/{id}/asset if no specific asset is assigned by the TO. If picking an asset is not allowed for this booking, or one already has been, 403 should be returned. If the booking is unknown, 404 should be returned. See (4.7) in the process flow. - trip execution
       tags:
         - trip execution
         - TO
@@ -542,7 +542,7 @@ paths:
         "404":
           $ref: "#/components/responses/404NotFound"
 
-  /legs/{id}:
+  /executions/{id}:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
@@ -565,7 +565,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/leg"
+                $ref: "#/components/schemas/execution"
         "401":
           $ref: "#/components/responses/401Unauthorized"
         "404":
@@ -579,7 +579,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/leg"
+              $ref: "#/components/schemas/execution"
         description: changed leg (e.g. with different duration or destination)
         required: true
       responses:
@@ -592,7 +592,7 @@ paths:
         "404":
           $ref: "#/components/responses/404NotFound"
 
-  /legs/{id}/asset:
+  /executions/{id}/asset:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
@@ -620,7 +620,7 @@ paths:
         "404":
           $ref: "#/components/responses/404NotFound"
 
-  /legs/{id}/events:
+  /executions/{id}/events:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
@@ -648,14 +648,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/legEvent"
+              $ref: "#/components/schemas/executionEvent"
       responses:
         "200":
           description: operation successful
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/leg"
+                $ref: "#/components/schemas/execution"
         "204":
           $ref: "#/components/responses/204NoContent"
         "400":
@@ -665,19 +665,19 @@ paths:
         "404":
           $ref: "#/components/responses/404NotFound"
 
-  /legs/{id}/progress:
+  /executions/{id}/progress:
     parameters:
       - $ref: "#/components/parameters/acceptLanguage"
       - $ref: "#/components/parameters/api"
       - $ref: "#/components/parameters/apiVersion"
       - name: id
         in: path
-        description: Leg identifier
+        description: Leg execution identifier
         required: true
         schema:
           type: string
     get:
-      description: Monitors the current location of the asset and duration & distance of the leg (see (4.7) in process flow)
+      description: Monitors the current location of the asset and duration & distance of the leg execution (see (4.7) in process flow)
       tags:
         - trip execution
         - TO
@@ -694,13 +694,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/legProgress"
+                $ref: "#/components/schemas/executionProgress"
         "401":
           $ref: "#/components/responses/401Unauthorized"
         "404":
           $ref: "#/components/responses/404NotFound"
     post:
-      description: Monitors the current location of the asset and duration & distance of the leg
+      description: Monitors the current location of the asset and duration & distance of the leg execution
       tags:
         - trip execution
         - MP
@@ -708,7 +708,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/legProgress"
+              $ref: "#/components/schemas/executionProgress"
       responses:
         "204":
           $ref: "#/components/responses/204NoContent"
@@ -1295,7 +1295,6 @@ components:
           required:
             - id
             - state
-            - leg
             - customer
             - token
           properties:
@@ -1339,7 +1338,7 @@ components:
         - customer
       properties:
         id:
-          description: unique ID (TO's perspective) for identifying this specific available (type of) asset
+          description: unique ID (TO's perspective) for identifying this specific available leg
           type: string
         customer:
           $ref: "#/components/schemas/customer"
@@ -1400,25 +1399,6 @@ components:
           $ref: "#/components/schemas/country"
         assetClass:
           $ref: "#/components/schemas/assetClass"
-
-    compositeOption:
-      description: this leg type should be used when returning multiple legs to fullfil a single request from A to B. For instance handling overlegs or when acting as broker for multiple sub contractors.
-      type: object
-      required:
-        - optionType
-        - parts
-      properties:
-        optionType:
-          type: string
-        id:
-          description: A unique id which can be referred to when creating a booking
-          type: string
-        pricing:
-          $ref: "#/components/schemas/fare"
-        parts:
-          type: array
-          items:
-            $ref: "#/components/schemas/simpleOption"
 
     condition:
       oneOf:
@@ -1776,9 +1756,9 @@ components:
       maxProperties: 2
       example: { "wheelchair": true }
 
-    leg:
+    execution:
       type: object
-      description: A OpenlegPlanner compatible definition of a leg (see OpenlegPlanner docs for reference)
+      description: The execution of a booked leg
       required:
         - from
         - to
@@ -1787,10 +1767,10 @@ components:
         - endTime
       properties:
         from:
-          description: The coordinate the TO should use to resolve leg start location
+          description: The place the TO should use to resolve leg start location
           $ref: "#/components/schemas/place"
         to:
-          description: The coordinate the TO should use to resolve leg finish location
+          description: The place the TO should use to resolve leg finish location
           $ref: "#/components/schemas/place"
         startTime:
           $ref: "#/components/schemas/timestamp"
@@ -1799,7 +1779,7 @@ components:
         mode:
           $ref: "#/components/schemas/typeOfAsset"
         state:
-          $ref: "#/components/schemas/legState"
+          $ref: "#/components/schemas/executionState"
         departureDelay:
           $ref: "#/components/schemas/duration"
         arrivalDelay:
@@ -1823,9 +1803,9 @@ components:
           $ref: "#/components/schemas/token"
           description: data to open a specific asset (e.g. QR code, image base64). This can be provided when using assign_asset, when it's not provided in the booking.
 
-    legEvent:
+    executionEvent:
       type: object
-      description: event for the leg
+      description: event for the execution
       required:
         - time
         - event
@@ -1850,9 +1830,9 @@ components:
         asset:
           $ref: "#/components/schemas/asset"
 
-    legProgress:
+    executionProgress:
       type: object
-      description: provides current asset location & duration and distance of the current leg
+      description: provides current asset location & duration and distance of the current leg execution
       required:
         - coordinates
       properties:
@@ -1863,9 +1843,9 @@ components:
         distance:
           $ref: "#/components/schemas/distance"
 
-    legState:
+    executionState:
       type: string
-      description: status of a leg
+      description: status of a leg execution
       enum:
         [
           NOT_STARTED,
@@ -1959,8 +1939,8 @@ components:
         physicalAddress:
           $ref: "#/components/schemas/address"
 
-    travelPlan:
-      description: The data for requesting available planning options
+    planningRequest:
+      description: The data for requesting available leg options
       allOf:
         - $ref: "#/components/schemas/period"
         - type: object
@@ -1978,7 +1958,7 @@ components:
               description: The number of people that want to travel
               type: number
             useAssets:
-              description: The specific asset(s), the user wishes to receive planning options for
+              description: The specific asset(s), the user wishes to receive leg options for
               type: array
               items:
                 type: string
@@ -1988,25 +1968,26 @@ components:
               items:
                 $ref: "#/components/schemas/user"
 
-    planningOption:
+    planning:
       type: object
       description: Available option matching the query.
+      required:
+        - validUntil
+        - conditions
+        - legOptions
       properties:
         validUntil:
           $ref: "#/components/schemas/timestamp"
         conditions:
-          description: An array of the conditions that apply to at least one of the options
+          description: An array of the conditions that apply to at least one of the leg options
           type: array
           items:
             $ref: "#/components/schemas/condition"
-        options:
+        legOptions:
+          description: Legs the TO has found that match the planning request
           type: array
           items:
-            oneOf:
-              - $ref: "#/components/schemas/singleOption"
-              - $ref: "#/components/schemas/compositeOption"
-            discriminator:
-              propertyName: optionType
+            $ref: "#/components/schemas/leg"
 
     polygon:
       type: object
@@ -2023,13 +2004,16 @@ components:
       items:
         $ref: "#/components/schemas/keyValue"
 
-    simpleOption:
+    leg:
+      description: A concrete option for a leg that matches the planning
       type: object
       required:
         - from
-        - typeOfAsset
         - conditions
       properties:
+        id:
+          description: A unique id which can be referred to when creating a booking, should not be used for sublegs
+          type: string
         from:
           $ref: "#/components/schemas/coordinates"
         to:
@@ -2042,36 +2026,18 @@ components:
           $ref: "#/components/schemas/typeOfAsset"
         pricing:
           $ref: "#/components/schemas/fare"
+        suboperator:
+          $ref: "#/components/schemas/suboperator"
+        parts:
+          description: The component legs if this leg is composed of multiple legs using different assets
+          type: array
+          items:
+            $ref: "#/components/schemas/leg"
         conditions:
-          description: Ids of the conditions in the parent planningOption that apply to this option
+          description: Ids of the conditions in the parent planning that apply to this leg
           type: array
           items:
             type: string
-        operatorName:
-          type: string
-          description: Name of the operator, these should not be included if they are the TO itself, could match Content-Language
-        operatorMaasId:
-          type: string
-          description: the maasId from the operator
-        operatorDescription:
-          type: string
-          description: short description of the operator, should match Content-Language
-        operatorContact:
-          type: string
-          description: contact information, should match Content-Language
-
-    singleOption:
-      allOf:
-        - $ref: "#/components/schemas/simpleOption"
-        - type: object
-          required:
-            - optionType
-          properties:
-            optionType:
-              type: string
-            id:
-              description: A unique id which can be referred to when creating a booking
-              type: string
 
     stationInformation:
       type: object
@@ -2147,7 +2113,26 @@ components:
           description: this field should contain the complete ID. E.g. NL:S:13121110 or BE:S:79640040
         country:
           $ref: "#/components/schemas/country"
-          
+
+    suboperator:
+      type: object
+      description: The operator of a leg or asset, in case this is not the TO itself but should be shown to the user
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the operator, could match Content-Language
+        maasId:
+          type: string
+          description: the maasId from the operator
+        description:
+          type: string
+          description: short description of the operator, should match Content-Language
+        contact:
+          type: string
+          description: contact information, should match Content-Language
+
     supportRequest:
       description: request for support
       type: object

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -63,8 +63,8 @@ paths:
       - $ref: "#/components/parameters/apiVersion"
     post:
       description:
-        Returns available transport options for given coordinates and radius. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
-        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `provideIds`, requesting the TO to provide unique IDs to reference to during communication with the MP.
+        Returns planning options for the given travel plan. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
+        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `bookable`, requesting the TO to provide booking IDs to reference to during communication with the MP.
         <p>see (2.1) in the process flow - planning
       tags:
         - planning
@@ -80,17 +80,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/planningCheck"
+              $ref: "#/components/schemas/travelPlan"
       responses:
         "201":
           description: Available transport methods matching the given query parameters. If no transport methods are available, an empty array is returned.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/planningOptions"
+                $ref: "#/components/schemas/planningOption"
           headers:
             Location:
-              description: The URI where the created options can be found, in case of 'provideIds' = true
+              description: The URI where the most up to date version of the created option can be found. Not required.
               schema:
                 type: string
                 example: "/planning-options/1234"
@@ -120,7 +120,7 @@ paths:
       - $ref: "#/components/parameters/apiVersion"
     post:
       description:
-        Creates a new `Booking` for the TO in **Pending** state. The ID of the posted booking should be the ID provided in the previous step (planningOptions).
+        Creates a new `Booking` for the TO in **Pending** state. The ID of the posted booking should be the ID provided in the previous step (planningOption).
         <p>The Booking may be modified in the response, e.g. location being adjusted for a more suitable pick-up location.
         In addition, the service may contain a **meta** attribute for arbitrary TO metadata that the TO needs later, and **token** attribute depicting how long the current state is valid.
         <p>The optional webhook can be used to post updates from TO to MP. If it isn't used, the subscription possibility in this API can be used or the events can be posted directly.
@@ -1955,8 +1955,8 @@ components:
         physicalAddress:
           $ref: "#/components/schemas/address"
 
-    planningCheck:
-      description: the request for available assets. User's location in comma separated form e.g. 60.123,27.456 (lat/long, WGS84)
+    travelPlan:
+      description: The data for requesting available planning options
       allOf:
         - $ref: "#/components/schemas/period"
         - type: object
@@ -1966,30 +1966,32 @@ components:
             from:
               $ref: "#/components/schemas/place"
             radius:
-              description: Maximum distance a user wants to travel to reach asset in metres, e.g. 500 metres
+              description: Maximum distance in meters a user wants to travel to reach the travel option
               type: number
             to:
               $ref: "#/components/schemas/place"
             travellers:
-              description: the amount of people that have to travel from `from` to `to` [https://github.com/efel85/TOMP-API/issues/56]
+              description: The number of people that want to travel
               type: number
             useAssets:
-              description: when you use the /operator/available-assets and you want to book a displayed asset, you must be able to request o a planning-option for the specific asset (with provideIds=true), post a booking with the provided id and send directly a commit. This field should contain the asset to book.
+              description: The specific asset(s), the user wishes to receive planning options for
               type: array
               items:
                 type: string
+                format: an asset id for this operator
             users:
               type: array
               items:
                 $ref: "#/components/schemas/user"
 
-    planningOptions:
+    planningOption:
       type: object
-      description: Available option matching the query. Optionally including asset information for claiming specific assets. The pricing is also included.
+      description: Available option matching the query.
       properties:
         validUntil:
           $ref: "#/components/schemas/timestamp"
         conditions:
+          description: An array of the conditions that apply to at least one of the results
           type: array
           items:
             $ref: "#/components/schemas/condition"

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -1970,7 +1970,7 @@ components:
               type: number
             to:
               $ref: "#/components/schemas/place"
-            travellers:
+            travelers:
               description: The number of people that want to travel
               type: number
             useAssets:

--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -162,7 +162,7 @@ paths:
         - booking
         - TO
       requestBody:
-        description: One of available legs, returned by /planning, with an ID.
+        description: One of available legs, returned by /plannings, with an ID.
         required: true
         content:
           application/json:


### PR DESCRIPTION
Resolves #140,
resolves #144,
closes #176,
fixes #184

# Changes
* changes provideIds to a query parameter called bookable (issue #144)
* changes planning request locations from `coordinates` to `place` (issue #140)
* updated descriptions around the planning module
* renamed planning results (<something>Leg) and leg to "leg" and "execution" to distinguish better between them
* restructured returned planning options objects to fix issue #176 and simplify it
* add GET /plannings/{id} path implied by the location header in the planning options response
* remove expires header in planning options (issue #184)
* rename travellers to travelers (a breaking spelling fix)