### PR TITLE
#147 Using a single url for multiple organizations

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -2594,6 +2594,15 @@ components:
         type: string
       description: The ID of the sending maas operator
       example: 1324A-DFB3482-32ACD
+    addressedTo:
+      in: header
+      name: addressed-to
+      required: false
+      schema:
+        type: string
+      description: The ID of the maas operator that has to receive this message
+      example: 1324A-DFB3482-32ACD
+
 
   securitySchemes:
     BasicAuth:


### PR DESCRIPTION
Header field used "addressed-to"