### PR TITLE
lat and lng should be required in coordinates

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -1677,6 +1677,9 @@ components:
     coordinates:
       type: object
       description: a lon, lat (WGS84, EPSG:4326)
+      required:
+        - lat
+        - lng
       properties:
         lng:
           type: number


### PR DESCRIPTION
Coordinates should always have latitude and longitude