### PR TITLE
#239 Reintroduce REJECTED state. Returning 409 is not enough, there m…

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -199,8 +199,6 @@ paths:
           $ref: "#/components/responses/401Unauthorized"
         "404":
           $ref: "#/components/responses/404NotFound"
-        "409":
-          $ref: "#/components/responses/409Conflict"
       callbacks: # webhooks
         # as described in https://swagger.io/docs/specification/callbacks/
         booking-operations:
@@ -1499,6 +1497,7 @@ components:
         [
           NEW,
           PENDING,
+          REJECTED,
           RELEASED,
           EXPIRED,
           CONDITIONAL_CONFIRMED,


### PR DESCRIPTION
…ight be no conflict, but there might be other reasons to reject a booking (like payment, administrative errors, ..) With the reintroduction of REJECTED 201 can be returned with a complete booking object to describe the last status.