### PR TITLE
Fix typo of `nrOftravelers`

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -2293,7 +2293,7 @@ components:
       type: object
       required:
         - from
-        - nrOftravelers
+        - nrOfTravelers
       properties:
         from:
           $ref: "#/components/schemas/place"


### PR DESCRIPTION
Property name is `nrOfTravelers` not `nrOftravelers`

I'd say this is a big issue. We are using automated tools to validate incoming requests. So the tool tries to find `nrOftravelers` and since it's not in the body it throws error.

Altough currently, we changed this manually in our spec file. So it wouldn't cause too much trouble if it is merged in next month.