### PR TITLE
Allow 410 response in POST /booking endpoint

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -157,6 +157,8 @@ paths:
           $ref: "#/components/responses/404NotFound"
         "409":
           $ref: "#/components/responses/409Conflict"
+        "410":
+          $ref: "#/components/responses/410Gone"
     get:
       description: Optional - Returns bookings that has been created earlier, selected on state.
       tags:


### PR DESCRIPTION
Seems that it makes sense to have this response. In /plannings we
return `validUntil` so TO should have some way of signaling that
given booking is not available to proceed with anymore. Seems that 410
is the most fitting response for this.

Unless we want to use 404 for this purpose? 