### PR TITLE
`unitType` is not required

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -2090,7 +2090,6 @@ components:
         - type: object
           required:
             - vatRate
-            - unitType
             - amount
           properties:
             type:


### PR DESCRIPTION
Fixes #304 

Wiki needs to be updated for this change.