### PR TITLE
325-add-cancelled-legstate

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -2306,6 +2306,7 @@ components:
               FINISH,
               TIME_EXTEND,
               TIME_POSTPONE,
+              CANCEL,
             ]
         comment:
           type: string
@@ -2344,6 +2345,7 @@ components:
           FINISHING,
           FINISHED,
           ISSUE_REPORTED,
+          CANCELLED,
         ]
 
     license:


### PR DESCRIPTION
extended 2 enums. Impacts WIKI as well (todo). LegEvent type is extended with 'CANCEL'