### PR TITLE
API spec: removed booking_intent hint on /planning endpoints

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -117,8 +117,8 @@ paths:
     post:
       description:
         Returns informative options for the given travel plan. <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
-        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `booking-intent`, requesting the TO to provide booking IDs to reference to during communication with the MP.
-        <p>see (2.1) in the process flow - planning.
+        During the routing phase this service can be used to check availability without any state changes.
+        <p>See (2.1) in the process flow - planning.
       tags:
         - planning
         - TO
@@ -160,8 +160,8 @@ paths:
       description:
         Returns bookable offers for the given travel plan. 
         <p>Start time can be defined, but is optional. If startTime is not provided, but required by the third party API, a default value of "Date.now()" is used. [from MaaS-API /listing].
-        During the routing phase this service can be used to check availability without any state changes. <p>In the final check, just before presenting the alternatives to the user, a call should be made using `booking-intent`, requesting the TO to provide booking IDs to reference to during communication with the MP.
-        <p>see (2.1) in the process flow - planning
+        During the routing phase this service can be used to check availability without any state changes.
+        <p>See (2.1) in the process flow - planning
       tags:
         - planning
         - TO
@@ -2064,6 +2064,8 @@ components:
     bookingRequest:
       description: A booking requested by the MP
       type: object
+      required:
+        - id
       properties:
         id:
           description: A unique identifier for the TO to know this booking by

--- a/plantuml/planned-trip-activity-diagram.plantuml
+++ b/plantuml/planned-trip-activity-diagram.plantuml
@@ -8,27 +8,41 @@ floating note right: Green nodes are \nimplemented by TOMP API
 
 partition "planning process" {
 :Create routes;
-#green:Search TOs;
-note right
-  operator module
-end note
-#green:Find out availability TOs;
-note right
-  /planning/inquiries
-end note
-#green:Prebook best routes;
-note right
-  /planning/offers
-end note
+#green:Search TOs for legs;
+repeat
+	if (offer required) then (yes)
+		#green:Find out availability TOs;
+		note right
+		  /planning/inquiries
+		end note
+		#green:Prebook best routes;
+		note right
+		  /planning/offers
+		end note
+	else (no)
+		:fetch external information\nfrom TO;
+	endif 
+repeat while(last TO?) is (no)
+->:yes;
 }
 
 :Propose best trips to end user;
 
 partition "booking process" {
-#green:Book leg per TO;
-note right
-  /bookings/
-end note
+repeat
+	if (offer required) then (yes)
+		#green:Book leg;
+		note right
+		  /bookings/
+		end note
+	else (no)
+		#green:One stop booking leg;
+		note right
+		  /bookings/one-stop
+		end note
+	endif
+repeat while(last TO?) is (no)
+->:yes;
 #green:Commit legs;
 note right
   /bookings/{id}/events COMMIT


### PR DESCRIPTION
removed booking_intent hint on /planning/inquiries and /planning/offers and added required flag to id field of booking requests and responses