### PR TITLE
Update TOMP-API.yaml - bug #568 : date type for birthdate

### DIFF
--- a/TOMP-API.yaml
+++ b/TOMP-API.yaml
@@ -2621,7 +2621,6 @@ components:
               format: date
             placeOfBirth:
               type: string
-              format: date
             countryOfBirth:
               $ref: "#/components/schemas/country"
             address:


### PR DESCRIPTION
Changed the type to string for placeOfBirth.