### PR TITLE
fixing output directory for merge-API.ps1 script

### DIFF
--- a/merge-API.ps1
+++ b/merge-API.ps1
@@ -97,7 +97,7 @@ Invoke-Expression $join
 #Set-Content -Path .\TOMP-API.yaml -Value $content -Encoding utf8
 
 $in  = '.\TOMP-API-BOM.yaml'
-$out = '.\TOMP-API.yaml'
+$out = "$($PWD.Path)\TOMP-API.yaml"
 
 If ($args[0] -eq 'mp') {
     $out = '.\TOMP-API-MP.yaml'


### PR DESCRIPTION
Output (TOMP-API.yaml) was not written into the TOMP-API directory where the merge-API.ps1 script is located. Now the output is written into the same directory where the merge-API.ps1 script is located